### PR TITLE
Use gnu99 instead of c99, as strdup is not part of C99

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -151,7 +151,9 @@ CPPFLAGS += -DLOCAL_BUILD
 CPPFLAGS += -D'DRAGEN_OS_VERSION="$(DRAGEN_OS_VERSION)"' 
 CPPFLAGS += -DVERSION_STRING="$(VERSION_STRING)"
 CXXFLAGS?=-std=c++11
-CFLAGS?=-std=c99 
+# Use gnu99 instead of c99, as strdup is not part of C99:
+# https://stackoverflow.com/questions/26284110/strdup-confused-about-warnings-implicit-declaration-makes-pointer-with
+CFLAGS?=-std=gnu99 
 LDFLAGS?=
 
 ifneq (,$(BOOST_INCLUDEDIR))


### PR DESCRIPTION
With `c99` only, `strdup` is not defined (see https://stackoverflow.com/questions/26284110/strdup-confused-about-warnings-implicit-declaration-makes-pointer-with for context). Consequently, https://github.com/Illumina/DRAGMAP/blob/ef182bda173d1ca9919b93fae99f068802ed20fc/thirdparty/dragen/src/common/hash_generation/gen_hash_table.c#L158 assigns an invalid pointer value to `dir`, which cannot be read afterwards (e.g. using gcc 9 in the Ubuntu 20.04 Docker image), leading to a segfault. `gcc` warns about this:

```
/DRAGMAP-1.2.1/thirdparty/dragen/src/common/hash_generation/gen_hash_table.c: In function 'setDefaultHashParams':
/DRAGMAP-1.2.1/thirdparty/dragen/src/common/hash_generation/gen_hash_table.c:158:24: warning: implicit declaration of function 'strdup'; did you mean 'strcmp'? [-Wimplicit-function-declaration]
  158 |     if (destDir) dir = strdup(destDir);
      |                        ^~~~~~
      |                        strcmp
/DRAGMAP-1.2.1/thirdparty/dragen/src/common/hash_generation/gen_hash_table.c:158:22: warning: assignment to 'char *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
  158 |     if (destDir) dir = strdup(destDir);
```