### PR TITLE
fix overflow number of reference contig

### DIFF
--- a/src/include/align/Alignment.hpp
+++ b/src/include/align/Alignment.hpp
@@ -55,9 +55,9 @@ struct AlignmentHeader {
   MapqType  mapq_              = -1;
   FlagType  flags_             = -1;
   int       position_          = -1;
-  short     reference_         = -1;
+  int       reference_         = -1;
   int       nextPosition_      = -1;
-  short     nextReference_     = -1;
+  int       nextReference_     = -1;
   int       templateLength_    = -1;
   int32_t   mateCoordinate_    = -1;
   bool      smithWatermanDone_ = false;
@@ -88,12 +88,12 @@ struct AlignmentHeader {
   bool     isSupplementaryAlignment() const { return flags_ & SUPPLEMENTARY_ALIGNMENT; }
   int      getPosition() const { return position_; }
   void     setPosition(const int position) { position_ = position; }
-  short    getReference() const { return reference_; }
-  void     setReference(unsigned short reference) { reference_ = reference; }
+  int      getReference() const { return reference_; }
+  void     setReference(unsigned int reference) { reference_ = reference; }
   int      getNextPosition() const { return nextPosition_; }
   void     setNextPosition(const int nextPosition) { nextPosition_ = nextPosition; }
-  short    getNextReference() const { return nextReference_; }
-  void     setNextReference(unsigned short nextReference) { nextReference_ = nextReference; }
+  int      getNextReference() const { return nextReference_; }
+  void     setNextReference(unsigned int nextReference) { nextReference_ = nextReference; }
   int      getTemplateLength() const { return templateLength_; }
   void     setTemplateLength(const int templateLength) { templateLength_ = templateLength; }
   int32_t  getMateCoordinate() const { return mateCoordinate_; }
@@ -314,7 +314,7 @@ private:
 
 struct SerializedSaTag {
   struct Header {
-    short    reference_ = 0;
+    int      reference_ = 0;
     int      position_  = 0;
     bool     reverse_   = 0;
     MapqType mapq_      = 0;
@@ -341,7 +341,7 @@ struct SerializedSaTag {
 
   std::size_t getByteSize() const { return sizeof(*this) + cigar_.getByteSize() - sizeof(cigar_); }
 
-  short                  getReference() const { return header_.reference_; }
+  int                    getReference() const { return header_.reference_; }
   int                    getPosition() const { return header_.position_; }
   bool                   reverse() const { return header_.reverse_; }
   MapqType               getMapq() const { return header_.mapq_; }


### PR DESCRIPTION
Dear DRAGMAP developer,

I encountered following bug with hg38 reference and additional many contigs (total1052041 contigs) .

`vector::_M_range_check: __n (which is 18446744073709547104) >= this->size() (which is 1052041)`

This bug occurred because the maximum number of short type reference contigs was exceeded.
I fixed related short type to int. I expect this fix to have little impact on memory usage and performance.